### PR TITLE
Add DACL enum + LDAP querying function

### DIFF
--- a/EDD/EDD.csproj
+++ b/EDD/EDD.csproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Compile Include="Amass.cs" />
     <Compile Include="Functions\ChangeAccountPassword.cs" />
+    <Compile Include="Functions\CustomLDAPQuery.cs" />
     <Compile Include="Functions\GetDomainDescription.cs" />
     <Compile Include="Functions\FindAdminSCH.cs" />
     <Compile Include="Functions\FindAdminWMI.cs" />
@@ -100,6 +101,7 @@
     <Compile Include="Functions\GetNetLoggedOn.cs" />
     <Compile Include="Functions\GetNetSession.cs" />
     <Compile Include="Functions\GetSidData.cs" />
+    <Compile Include="Functions\GetUserDACL.cs" />
     <Compile Include="Functions\GetUsersWithSpns.cs" />
     <Compile Include="Functions\JoinGroupByName.cs" />
     <Compile Include="Functions\JoinGroupBySid.cs" />
@@ -108,6 +110,7 @@
     <Compile Include="Models\EDDException.cs" />
     <Compile Include="Models\EDDFunction.cs" />
     <Compile Include="LDAP.cs" />
+    <Compile Include="Models\Extensions.cs" />
     <Compile Include="Models\ParsedArgs.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/EDD/Functions/CustomLDAPQuery.cs
+++ b/EDD/Functions/CustomLDAPQuery.cs
@@ -1,0 +1,24 @@
+﻿using System.DirectoryServices;
+using System.Collections.Generic;
+
+using EDD.Models;
+
+namespace EDD.Functions
+{
+    internal class CustomLDAPQuery : EDDFunction
+    {
+        public override string FunctionName => "Query";
+
+        public override string[] Execute(ParsedArgs args)
+        {
+            List<string> QueryOutList = new List<string>();
+
+            if (args.ldapQuery == null) { throw new EDDException("No LDAP query supplied"); }
+
+            SearchResultCollection QueryOut = LDAP.CustomSearchLDAP(args.ldapQuery);
+            foreach (SearchResult res in QueryOut) { QueryOutList.Add($"{res.Properties["CN"][0]}\t\t{res.Path}"); }
+
+            return QueryOutList.ToArray();
+        }
+    }
+}

--- a/EDD/Functions/GetUserDACL.cs
+++ b/EDD/Functions/GetUserDACL.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using System.DirectoryServices;
+using System.Security.Principal;
+using System.Collections.Generic;
+
+using EDD.Models;
+
+namespace EDD.Functions
+{
+    internal class GetUserDACL : EDDFunction
+    {
+        public override string FunctionName => "GetUserDACL";
+
+        public override string[] Execute(ParsedArgs args)
+        {
+
+            string CN = args.CanonicalName.Replace('.', ' ');
+            string[] ADRights = Data.ADRights;
+            bool AllRights = false;
+
+            Data.ControlType ct = Data.ControlType.Inactive;
+
+            List<String> QueryOutList = new List<String>();
+            StringBuilder outData = new StringBuilder();
+
+            DirectoryEntry entry = new DirectoryEntry();
+            DirectorySearcher searcher = new DirectorySearcher(entry);
+
+            searcher.Filter = $"(cn={CN})";
+
+            ActiveDirectorySecurity objACL = searcher.FindOne().GetDirectoryEntry().ObjectSecurity;
+
+            foreach (ActiveDirectoryAccessRule ACE in objACL.GetAccessRules(true, true, typeof(NTAccount)))
+            {
+                if (ADRights != Data.ADRights || AllRights)
+                {
+                    if (ADRights.Any(ACE.ActiveDirectoryRights.ToString().Contains) && ct != Data.ControlType.Inactive)
+                    {
+                        QueryOutList.Add(ACLUtils.returnACEData(outData, ACE, ct));
+                    }
+                    else if (ADRights.Any(ACE.ActiveDirectoryRights.ToString().Contains)) { QueryOutList.Add(ACLUtils.returnACEData(outData, ACE)); }
+                }
+                else { QueryOutList.Add(ACLUtils.returnACEData(outData, ACE)); }
+            }
+
+            return QueryOutList.ToArray();
+        }
+
+        public class ACLUtils
+        {
+
+            public static string returnACEData(StringBuilder sb, ActiveDirectoryAccessRule ACE)
+            {
+                sb.AppendLine($"{nameof(ACE.ActiveDirectoryRights),-25}: {ACE.ActiveDirectoryRights}\n" +
+                    $"{nameof(ACE.AccessControlType),-25}: {ACE.AccessControlType}\n");
+                if (ACE.IdentityReference.ToString().Contains("S-1-5-32"))
+                {
+                    Int32 index = Int32.Parse(ACE.IdentityReference.ToString().Split('-')[4]);
+                    sb.AppendLine($"{nameof(ACE.IdentityReference),-25}: {((Data.BuiltinSID)index).ToDescription()}");
+                }
+                else { sb.AppendLine($"{nameof(ACE.IdentityReference),-25}: {ACE.IdentityReference}"); }
+                sb.AppendLine($"{nameof(ACE.ObjectType),-25}: {ACE.ObjectType}\n" +
+                    $"{nameof(ACE.ObjectFlags),-25}: {ACE.ObjectFlags}");
+                if (ACE.IsInherited)
+                {
+                    if (ACE.PropagationFlags.ToString() != "None") { sb.AppendLine($"{nameof(ACE.PropagationFlags),-25}: {ACE.PropagationFlags}"); }
+                    sb.AppendLine($"{nameof(ACE.InheritanceFlags),-25}: {ACE.InheritanceFlags}\n" +
+                        $"{nameof(ACE.InheritanceType),-25}: {ACE.InheritanceType}\n" +
+                        $"{nameof(ACE.InheritedObjectType),-25}: {ACE.InheritedObjectType}");
+                }
+
+                sb.AppendLine();
+
+                return sb.ToString();
+            }
+
+            public static string returnACEData(StringBuilder sb, ActiveDirectoryAccessRule ACE, Data.ControlType ct)
+            {
+                if (ct.Equals(Enum.Parse(typeof(Data.ControlType), ACE.AccessControlType.ToString())))
+                {
+                    sb.AppendLine($"{nameof(ACE.ActiveDirectoryRights),-25}: {ACE.ActiveDirectoryRights}\n" +
+                        $"{nameof(ACE.AccessControlType),-25}: {ACE.AccessControlType}\n");
+                    if (ACE.IdentityReference.ToString().Contains("S-1-5-32"))
+                    {
+                        Int32 index = Int32.Parse(ACE.IdentityReference.ToString().Split('-')[4]);
+                        sb.AppendLine($"{nameof(ACE.IdentityReference),-25}: {((Data.BuiltinSID)index).ToDescription()}");
+                    }
+                    else { sb.AppendLine($"{nameof(ACE.IdentityReference),-25}: {ACE.IdentityReference}"); }
+                    sb.AppendLine($"{nameof(ACE.ObjectType),-25}: {ACE.ObjectType}\n" +
+                        $"{nameof(ACE.ObjectFlags),-25}: {ACE.ObjectFlags}");
+                    if (ACE.IsInherited)
+                    {
+                        if (ACE.PropagationFlags.ToString() != "None") { sb.AppendLine($"{nameof(ACE.PropagationFlags)}: {ACE.PropagationFlags}"); }
+                        sb.AppendLine($"{nameof(ACE.InheritanceFlags),-25}: {ACE.InheritanceFlags}\n" +
+                            $"{nameof(ACE.InheritanceType),-25}: {ACE.InheritanceType}\n" +
+                            $"{nameof(ACE.InheritedObjectType),-25}: {ACE.InheritedObjectType}");
+                    }
+                    sb.AppendLine();
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/EDD/Functions/GetUserDACL.cs
+++ b/EDD/Functions/GetUserDACL.cs
@@ -17,7 +17,7 @@ namespace EDD.Functions
         {
 
             string CN = args.CanonicalName.Replace('.', ' ');
-            string[] ADRights = Data.ADRights;
+            string[] ADRights = args.ADRights.Split(',');
             bool AllRights = false;
 
             Data.ControlType ct = Data.ControlType.Inactive;

--- a/EDD/Models/Data.cs
+++ b/EDD/Models/Data.cs
@@ -1,12 +1,83 @@
-﻿namespace EDD.Models
+﻿using System.ComponentModel;
+
+namespace EDD.Models
 {
     internal class Data
     {
-        public static string[] BlacklistedDesc = { 
+        public static string[] BlacklistedDesc = {
             "Built-in account for administering the computer/domain",
             "Built-in account for guest access to the computer/domain",
             "Key Distribution Center Service Account",
             "A user account managed by the system."
         };
+
+        public static string[] ADRights = { "GenericAll", "GenericRead", "GenericWrite", "GenericExecute", "ReadProperty", "ReadControl",
+                "WriteProperty", "WriteOwner", "WriteDacl", "ListChildren", "ListObject", "CreateChild", "Delete", "DeleteChild", "DeleteTree",
+                "ExtendedRight", "Self", "Syncronize", "AccessSystemSecurity"};
+
+        public enum ControlType
+        {
+            Inactive = 0,
+            Deny = 1,
+            Allow = 2
+        }
+
+        public enum BuiltinSID
+        {
+            [Description("Administrators")]
+            Administrators = 544,
+            [Description("Users")]
+            Users = 545,
+            [Description("Guests")]
+            Guests = 546,
+            [Description("Power Users")]
+            Power_Users = 547,
+            [Description("Account Operators")]
+            Account_Operators = 548,
+            [Description("Server Operators")]
+            Server_Operators = 549,
+            [Description("Print Operators")]
+            Print_Operators = 550,
+            [Description("Backup Operators")]
+            Backup_Operators = 551,
+            [Description("Replicators")]
+            Replicators = 552,
+            [Description("Builtin\\Pre-Windows 2000 Compatable Access")]
+            PreWin2000 = 554,
+            [Description("Builtin\\Remote Desktop Users")]
+            RemoteDesktopUsers = 555,
+            [Description("Builtin\\Network Configuration Operators")]
+            NetConfigOperators = 556,
+            [Description("Builtin\\Incoming Forest Trust Builders")]
+            IncomingForestTrustBuilders = 557,
+            [Description("Builtin\\Performance Monitor Users")]
+            PerformanceMonitorUsers = 558,
+            [Description("Builtin\\Performance Log Users")]
+            PerformanceLogUsers = 559,
+            [Description("Builtin\\Windows Authorization Access Group")]
+            WinAuthGroup = 560,
+            [Description("Builtin\\Terminal Server License Servers")]
+            TerminalSvr = 561,
+            [Description("Builtin\\Distributed COM Users")]
+            DCOMUsers = 562,
+            [Description("Builtin\\Cryptographic Operators")]
+            CrytpoOperators = 569,
+            [Description("Builtin\\Event Log Readers")]
+            EventLogReaders = 573,
+            [Description("Builtin\\Certificate Service DCOM Access")]
+            CSDCOMAccess = 574,
+            [Description("Builtin\\RDS Remote Access Servers")]
+            RemoteAccessSvr = 575,
+            [Description("Builtin\\RDS Endpoint Servers")]
+            RDSESvr = 576,
+            [Description("Builtin\\RDS Management Servers")]
+            RDSMSvr = 577,
+            [Description("Builtin\\Hyper-V Administrators")]
+            HVAdmins = 578,
+            [Description("Builtin\\Access Control Assistance Operators")]
+            ACAOperators = 579,
+            [Description("Builtin\\Remote Management Users")]
+            RemoteManageUsers = 580
+        }
     }
 }

--- a/EDD/Models/Extensions.cs
+++ b/EDD/Models/Extensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Reflection;
+using System.ComponentModel;
+
+namespace EDD.Models
+{
+    public static class Extensions
+    {
+        public static string ToDescription(this Enum value)
+        {
+            FieldInfo field = value.GetType().GetField(value.ToString());
+            DescriptionAttribute attribute = Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) as DescriptionAttribute;
+            return attribute == null ? value.ToString() : attribute.Description;
+        }
+    }
+}

--- a/EDD/Models/ParsedArgs.cs
+++ b/EDD/Models/ParsedArgs.cs
@@ -4,6 +4,7 @@ namespace EDD.Models
 {
     public class ParsedArgs
     {
+        public string ADRights { get; set; }
         public string GroupName { get; set; }
         public string ComputerName { get; set; }
         public string ProcessName { get; set; }

--- a/EDD/Models/ParsedArgs.cs
+++ b/EDD/Models/ParsedArgs.cs
@@ -9,6 +9,7 @@ namespace EDD.Models
         public string ProcessName { get; set; }
         public string Password { get; set; }
         public string UserName { get; set; }
+        public string CanonicalName { get; set; }
         public string DomainName { get; set; }
         public string SharePath { get; set; }
         public int Threads { get; set; }

--- a/EDD/Program.cs
+++ b/EDD/Program.cs
@@ -20,12 +20,14 @@ namespace EDD
                 string functionName = null;
                 string fileSavePath = null;
                 bool show_help = false;
+                bool list_functions = false;
 
                 var p = new OptionSet()
                 {
                     {"f|function=", "the function you want to use", (v) => functionName = v},
                     {"o|output=", "the path to the file to save", (v) => fileSavePath = v},
                     {"c|computername=", "the computer you are targeting", (v) => parsedArgs.ComputerName = v},
+                    {"n|canonicalname=", "canonical name for domain user", (v) => parsedArgs.CanonicalName = v},
                     {"d|domainname=", "the computer you are targeting", (v) => parsedArgs.DomainName = v},
                     {"g|groupname=", "the domain group you are targeting", (v) => parsedArgs.GroupName = v},
                     {"p|processname=", "the process you are targeting", (v) => parsedArgs.ProcessName = v},
@@ -36,6 +38,7 @@ namespace EDD
                     {"s|search=", "the search term(s) for FindInterestingDomainShareFile separated by a comma (,), accepts wildcards",
                         (string s) => parsedArgs.SearchTerms = s?.Split(',')},
                     {"sharepath=", "the specific share to search for interesting files", (v) => parsedArgs.SharePath = v},
+                    {"l|listfunctions", "list EDD functions available", v => list_functions = v != null},
                     {"h|help", "show this message and exit", v => show_help = v != null}
                 };
 
@@ -110,6 +113,16 @@ namespace EDD
             Console.WriteLine("Arguments:");
             p.WriteOptionDescriptions(Console.Out);
         }
+
+        static void FunctionReturn()
+        {
+            Console.WriteLine("EDD functions:");
+            foreach (EDDFunction function in _functions)
+            {
+                Console.WriteLine($"{function.FunctionName}");
+            }
+        }
+
 
         static void InitFunctions()
         {

--- a/EDD/Program.cs
+++ b/EDD/Program.cs
@@ -35,6 +35,7 @@ namespace EDD
                     {"u|username=", "the domain account you are targeting", (v) => parsedArgs.UserName = v},
                     {"t|threads=", "the number of threads to run (default: 5)", (int t) => parsedArgs.Threads = t},
                     {"q|query=", "custom LDAP filter to search", (v) => parsedArgs.ldapQuery = v},
+                    {"a|adright=", "Active Directory Rights to return, separated by commas", (v) => parsedArgs.ADRights = v},
                     {"s|search=", "the search term(s) for FindInterestingDomainShareFile separated by a comma (,), accepts wildcards",
                         (string s) => parsedArgs.SearchTerms = s?.Split(',')},
                     {"sharepath=", "the specific share to search for interesting files", (v) => parsedArgs.SharePath = v},

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ The following functions can be used with the -f flag to specify the data you wan
 	getreadabledomainshares - Get a list of all readable domain shares
 
 ### User Information
-	changeaccountpassword - change the password for a targeted account
+	changeaccountpassword - Change the password for a targeted account
+	customldapquery - Set arbitrary LDAP filter to search for objects
+	getuserdacl - Returns DACL of a specified domain object
 	getnetlocalgroupmember - Returns a list of all users in a local group on a remote system
 	getdomaingroupmember - Returns a list of all users in a domain group
 	getdomainuser - Retrieves info about specific user (name, description, SID, Domain Groups)
+	getdomaindescription - returns domain objects with non-standard account descriptions
 	getnetsession - Returns a list of accounts with sessions on the targeted system
 	getnetloggedon - Returns a list of accounts logged into the targeted system
 	getuserswithspns - Returns a list of all domain accounts that have a SPN associated with them


### PR DESCRIPTION
Added two functions:
* CustomLDAPQuery - allows an operator to execute arbitrary LDAP queries and return resulting object's canonical name and path
* GetUserDACL - returns the DACL of a specified user via canonical name. Added -n | --canonicalname= flag for this function. spaces in a canonical name must be replaced by a `.` and `-a | --adright=` to allow for an operator to specify only the ADRight they want returned instead of the entire DACL
